### PR TITLE
added tests with jUnit 5 and MockK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,15 @@ dependencies {
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo'
+    // exclude for use junit 5 and mockK 
+    testImplementation ('org.springframework.boot:spring-boot-starter-test') {
+        exclude module:  'junit'
+        exclude module: 'mockito-core'
+    }
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+    testImplementation 'com.ninja-squad:springmockk:1.1.2'
 }
 
 compileKotlin {
@@ -45,4 +52,8 @@ compileTestKotlin {
         freeCompilerArgs = ['-Xjsr305=strict']
         jvmTarget = '1.8'
     }
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src/main/resources/junit-platform.properties
+++ b/src/main/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.testinstance.lifecycle.default=per_class

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/CreationUtils.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/CreationUtils.kt
@@ -1,0 +1,166 @@
+package poc.renanpelicari.tinybrms
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import poc.renanpelicari.tinybrms.dataprovider.domain.AllowedAttribute
+import poc.renanpelicari.tinybrms.dataprovider.domain.Attribute
+import poc.renanpelicari.tinybrms.dataprovider.domain.Matcher
+import poc.renanpelicari.tinybrms.dataprovider.domain.Rule
+import poc.renanpelicari.tinybrms.dataprovider.enums.Expression
+import poc.renanpelicari.tinybrms.entrypoint.vo.AllowedAttributeVo
+import poc.renanpelicari.tinybrms.entrypoint.vo.AttributeVo
+import poc.renanpelicari.tinybrms.entrypoint.vo.MatcherVo
+import poc.renanpelicari.tinybrms.entrypoint.vo.RuleVo
+
+open class CreationUtils {
+    companion object {
+        fun createAllowedAttribute(
+                _id: String = "",
+                attribute: String = "examesFemininos",
+                description: String = "Códigos de exames para o sexo feminino",
+                values: Set<String> = setOf("MAMO", "MAMD", "UMAM")
+
+        ) = AllowedAttribute(
+                _id = _id,
+                attribute = attribute,
+                description = description,
+                values = values
+        )
+
+        fun createAllowedAttributeJson(): String {
+            return ObjectMapper().writeValueAsString(createAllowedAttribute())
+        }
+
+        fun createAllowedAttributeJson(
+                _id: String = "1",
+                attribute: String = "examesFemininos",
+                description: String = "Códigos de exames para o sexo feminino",
+                values: Set<String> = setOf("MAMO", "MAMD", "UMAM")
+        ): String {
+            return ObjectMapper().writeValueAsString(createAllowedAttribute(_id, attribute, description, values))
+        }
+
+        fun createAttribute(
+                _id: String = "",
+                name: String = "sexo",
+                description: String = "Sexo do paciente"
+
+        ) = Attribute(
+                _id = _id,
+                name = name,
+                description = description
+        )
+
+        fun createAttributeJson(): String {
+            return ObjectMapper().writeValueAsString(createAttribute())
+        }
+
+        fun createAttributeJson(_id: String = "1",
+                                name: String = "sexo",
+                                description: String = "Sexo do paciente"): String {
+            return ObjectMapper().writeValueAsString(createAttribute(_id, name, description))
+        }
+
+        fun createMatcher(
+                _id: String = "",
+                name: String = "sexoFem",
+                description: String = "Sexo Feminino",
+                attribute: Attribute = createAttribute(),
+                expression: Expression = Expression.EQUAL_NOT_MATCH_CASE,
+                values: Set<String> = setOf("F")
+        ) = Matcher(
+                _id = _id,
+                name = name,
+                description = description,
+                attribute = attribute,
+                expression = expression,
+                values = values
+        )
+
+        fun createMatcherJson(): String {
+            return ObjectMapper().writeValueAsString(createMatcher())
+        }
+
+        fun createMatcherJson(_id: String = "1",
+                              name: String = "sexoFem",
+                              description: String = "Sexo Feminino",
+                              attribute: Attribute = createAttribute(),
+                              expression: Expression = Expression.EQUAL_NOT_MATCH_CASE,
+                              values: Set<String> = setOf("F")): String {
+            return ObjectMapper().writeValueAsString(createMatcher(_id, name, description, attribute, expression, values))
+        }
+
+        fun createRule(
+                _id: String = "",
+                name: String = "exameFemininos",
+                description: String = "Regras para liberação de exames femininos",
+                matchers: Set<Matcher> = setOf(createMatcher()),
+                allowedValues: Set<AllowedAttribute> = setOf(createAllowedAttribute())
+
+        ) = Rule(
+                _id = _id,
+                name = name,
+                description = description,
+                matchers = matchers,
+                allowedValues = allowedValues
+        )
+
+        fun createRuleJson(): String {
+            return ObjectMapper().writeValueAsString(createRule())
+        }
+
+        fun createRuleJson(_id: String = "1",
+                           name: String = "exameFemininos",
+                           description: String = "Regras para liberação de exames femininos",
+                           matchers: Set<Matcher> = setOf(createMatcher()),
+                           allowedValues: Set<AllowedAttribute> = setOf(createAllowedAttribute())
+        ): String {
+            return ObjectMapper().writeValueAsString(createRule(
+                    _id, name, description, matchers, allowedValues
+            ))
+        }
+
+        fun createAllowedAttributeVo(
+                attribute: String = "examesFemininos",
+                description: String = "Códigos de exames para o sexo feminino",
+                values: Set<String> = setOf("MAMO", "MAMD", "UMAM", "HOLT", "CARD", "ERGO", "TGO")
+        ) = AllowedAttributeVo(
+                attribute = attribute,
+                description = description,
+                values = values
+        )
+
+        fun createAttributeVo(
+                name: String = "sexo",
+                description: String = "Sexo do paciente"
+        ) = AttributeVo(
+                name = name,
+                description = description
+        )
+
+        fun createMatcherVo(
+                name: String = "sexoFemi",
+                description: String = "Sexo Feminino",
+                attribute: Attribute = createAttribute(),
+                expression: Expression = Expression.EQUAL_NOT_MATCH_CASE,
+                values: Set<String> = setOf("F")
+        ) = MatcherVo(
+                name = name,
+                description = description,
+                attribute = attribute,
+                expression = expression,
+                values = values
+        )
+
+        fun createRuleVo(
+                name: String = "exameFemininos",
+                description: String = "Regras para liberação de exames femininos",
+                matchers: Set<Matcher> = setOf(createMatcher()),
+                allowedValues: Set<AllowedAttribute> = setOf(createAllowedAttribute())
+        ) = RuleVo(
+                name = name,
+                description = description,
+                matchers = matchers,
+                allowedValues = allowedValues
+        )
+    }
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/TinyBrmsApplicationTests.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/TinyBrmsApplicationTests.kt
@@ -1,11 +1,11 @@
 package poc.renanpelicari.tinybrms
 
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 @SpringBootTest
 class TinyBrmsApplicationTests {
 

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/DeleteAllowedAttributeUseCaseTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/DeleteAllowedAttributeUseCaseTest.kt
@@ -1,0 +1,41 @@
+package poc.renanpelicari.tinybrms.business.usecase
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import poc.renanpelicari.tinybrms.dataprovider.repository.AllowedAttributeRepository
+
+@ExtendWith(MockKExtension::class)
+class DeleteAllowedAttributeUseCaseTest {
+
+    @InjectMockKs
+    lateinit var deleteAllowedAttributeUseCase: DeleteAllowedAttributeUseCase
+
+    @MockK
+    lateinit var allowedAttributeRepository: AllowedAttributeRepository
+
+    @BeforeAll
+    fun setup() {
+        every { allowedAttributeRepository.deleteById("1") } answers { nothing }
+        every { allowedAttributeRepository.deleteAll() } answers { nothing }
+    }
+
+    @Test
+    fun `Should delete an Attribute by ID`() {
+        deleteAllowedAttributeUseCase.execute("1")
+
+        verify(exactly = 1) { allowedAttributeRepository.deleteById("1") }
+    }
+
+    @Test
+    fun `Should delete all Attributes`() {
+        deleteAllowedAttributeUseCase.execute()
+
+        verify(exactly = 1) { allowedAttributeRepository.deleteAll() }
+    }
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/DeleteAttributeUseCaseTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/DeleteAttributeUseCaseTest.kt
@@ -1,0 +1,41 @@
+package poc.renanpelicari.tinybrms.business.usecase
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import poc.renanpelicari.tinybrms.dataprovider.repository.AllowedAttributeRepository
+
+@ExtendWith(MockKExtension::class)
+internal class DeleteAttributeUseCaseTest {
+
+    @InjectMockKs
+    lateinit var deleteAllowedAttributeUseCase: DeleteAllowedAttributeUseCase
+
+    @MockK
+    lateinit var allowedRepository: AllowedAttributeRepository
+
+    @BeforeEach
+    fun setUp() {
+        every { allowedRepository.deleteById("1") } answers { nothing }
+        every { allowedRepository.deleteAll() } answers { nothing }
+    }
+
+    @Test
+    fun `Should delete an Attribute by ID`() {
+        deleteAllowedAttributeUseCase.execute("1")
+
+        verify(exactly = 1) { allowedRepository.deleteById("1") }
+    }
+
+    @Test
+    fun `Should delete all Attributes`() {
+        deleteAllowedAttributeUseCase.execute()
+
+        verify(exactly = 1) { allowedRepository.deleteAll() }
+    }
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/DeleteMatcherUseCaseTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/DeleteMatcherUseCaseTest.kt
@@ -1,0 +1,42 @@
+package poc.renanpelicari.tinybrms.business.usecase
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import poc.renanpelicari.tinybrms.dataprovider.repository.MatcherRepository
+
+@ExtendWith(MockKExtension::class)
+internal class DeleteMatcherUseCaseTest {
+
+    @InjectMockKs
+    lateinit var deleteMatcherUseCase: DeleteMatcherUseCase
+
+    @MockK
+    lateinit var matcherRepository: MatcherRepository
+
+
+    @BeforeEach
+    fun setup() {
+        every { matcherRepository.deleteById("1") } answers { nothing }
+        every { matcherRepository.deleteAll() } answers { nothing }
+    }
+
+    @Test
+    fun `Should delete an Attribute by ID`() {
+        deleteMatcherUseCase.execute("1")
+
+        verify(exactly = 1) { matcherRepository.deleteById("1") }
+    }
+
+    @Test
+    fun `Should delete all Attributes`() {
+        deleteMatcherUseCase.execute()
+
+        verify(exactly = 1) { matcherRepository.deleteAll() }
+    }
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/DeleteRuleUseCaseTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/DeleteRuleUseCaseTest.kt
@@ -1,0 +1,42 @@
+package poc.renanpelicari.tinybrms.business.usecase
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import poc.renanpelicari.tinybrms.dataprovider.repository.RuleRepository
+
+@ExtendWith(MockKExtension::class)
+internal class DeleteRuleUseCaseTest {
+
+    @InjectMockKs
+    lateinit var deleteRuleUseCase: DeleteRuleUseCase
+
+    @MockK
+    lateinit var ruleRepository: RuleRepository
+
+
+    @BeforeEach
+    fun setup() {
+        every { ruleRepository.deleteById("1") } answers { nothing }
+        every { ruleRepository.deleteAll() } answers { nothing }
+    }
+
+    @Test
+    fun `Should delete an Attribute by ID`() {
+        deleteRuleUseCase.execute("1")
+
+        verify(exactly = 1) { ruleRepository.deleteById("1") }
+    }
+
+    @Test
+    fun `Should delete all Attributes`() {
+        deleteRuleUseCase.execute()
+
+        verify(exactly = 1) { ruleRepository.deleteAll() }
+    }
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/FindAllAllowedAttributesUseCaseTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/FindAllAllowedAttributesUseCaseTest.kt
@@ -1,0 +1,41 @@
+package poc.renanpelicari.tinybrms.business.usecase
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import poc.renanpelicari.tinybrms.CreationUtils
+import poc.renanpelicari.tinybrms.dataprovider.repository.AllowedAttributeRepository
+
+@ExtendWith(MockKExtension::class)
+internal class FindAllAllowedAttributesUseCaseTest {
+
+    @InjectMockKs
+    lateinit var findAllAllowedAttributesUseCase: FindAllAllowedAttributesUseCase
+
+    @MockK
+    lateinit var allowedAttributeRepository: AllowedAttributeRepository
+
+    private val allowedAtributes = CreationUtils.createAllowedAttribute()
+    val list = listOf(allowedAtributes)
+
+    @BeforeEach
+    fun setup() {
+        every { allowedAttributeRepository.findAll() } returns list.toList()
+    }
+
+    @Test
+    fun `When findAll AllowedAttributes should return a list of AllowedAttributes`() {
+        val listOfAllowedAttributes = findAllAllowedAttributesUseCase.execute()
+
+        assertThat(list).containsExactlyElementsOf(listOfAllowedAttributes)
+
+        verify(exactly = 1) { allowedAttributeRepository.findAll() }
+    }
+
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/FindAllAttributesUseCaseTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/FindAllAttributesUseCaseTest.kt
@@ -1,0 +1,40 @@
+package poc.renanpelicari.tinybrms.business.usecase
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import poc.renanpelicari.tinybrms.CreationUtils
+import poc.renanpelicari.tinybrms.dataprovider.repository.AttributeRepository
+
+@ExtendWith(MockKExtension::class)
+internal class FindAllAttributesUseCaseTest {
+
+    @InjectMockKs
+    lateinit var findAllAttributesUseCase: FindAllAttributesUseCase
+
+    @MockK
+    lateinit var attributeRepository: AttributeRepository
+
+    var list = listOf(CreationUtils.createAttribute(), CreationUtils.createAttribute())
+
+    @BeforeAll
+    fun setup() {
+        every { attributeRepository.findAll() } returns list
+    }
+
+    @Test
+    fun `When find all Attributes should return a list of Attributes`() {
+        val listOfattributes = findAllAttributesUseCase.execute()
+
+        assertThat(list.sortedBy { attr -> attr.name }).containsExactlyElementsOf(listOfattributes)
+
+        verify(exactly = 1) { attributeRepository.findAll() }
+    }
+
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/FindAllMatchersUseCaseTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/FindAllMatchersUseCaseTest.kt
@@ -1,0 +1,39 @@
+package poc.renanpelicari.tinybrms.business.usecase
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import poc.renanpelicari.tinybrms.CreationUtils
+import poc.renanpelicari.tinybrms.dataprovider.repository.MatcherRepository
+
+@ExtendWith(MockKExtension::class)
+internal class FindAllMatchersUseCaseTest {
+
+    @InjectMockKs
+    lateinit var findAllMatchersUseCase: FindAllMatchersUseCase
+
+    @MockK
+    lateinit var matcherRepository: MatcherRepository
+
+    var list = listOf(CreationUtils.createMatcher(), CreationUtils.createMatcher())
+
+    @BeforeEach
+    fun setup() {
+        every { matcherRepository.findAll() } returns list.toList()
+    }
+
+    @Test
+    fun `When findAll attributes should return a list of Attributes`() {
+        val listOfmatchers = findAllMatchersUseCase.execute()
+
+        assertThat(list).containsExactlyElementsOf(listOfmatchers)
+
+        verify(exactly = 1) { matcherRepository.findAll() }
+    }
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/FindAllRulesUseCaseTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/FindAllRulesUseCaseTest.kt
@@ -1,0 +1,41 @@
+package poc.renanpelicari.tinybrms.business.usecase
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import poc.renanpelicari.tinybrms.CreationUtils
+import poc.renanpelicari.tinybrms.dataprovider.domain.Rule
+import poc.renanpelicari.tinybrms.dataprovider.repository.RuleRepository
+
+@ExtendWith(MockKExtension::class)
+internal class FindAllRulesUseCaseTest {
+
+    @InjectMockKs
+    lateinit var findAllRulesUseCase: FindAllRulesUseCase
+
+    @MockK
+    lateinit var ruleRepository: RuleRepository
+
+    private val list: List<Rule> = listOf(CreationUtils.createRule())
+
+    @BeforeEach
+    fun setup() {
+        every { ruleRepository.findAll() } returns list
+    }
+
+    @Test
+    fun `When findAll rules should return a list of Rules`() {
+        val listOfRules = findAllRulesUseCase.execute()
+
+        assertThat(list).containsExactlyElementsOf(listOfRules)
+
+        verify(exactly = 1) { ruleRepository.findAll() }
+    }
+
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/RegisterAllowedAttributeUseCaseTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/RegisterAllowedAttributeUseCaseTest.kt
@@ -1,0 +1,43 @@
+package poc.renanpelicari.tinybrms.business.usecase
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import poc.renanpelicari.tinybrms.CreationUtils
+import poc.renanpelicari.tinybrms.dataprovider.repository.AllowedAttributeRepository
+
+@ExtendWith(MockKExtension::class)
+internal class RegisterAllowedAttributeUseCaseTest {
+
+    @InjectMockKs
+    lateinit var registerAllowedAttributeUseCase: RegisterAllowedAttributeUseCase
+
+    @MockK
+    lateinit var allowedAttributeRepository: AllowedAttributeRepository
+
+    private val allowedAttribute = CreationUtils.createAllowedAttribute()
+
+    @BeforeEach
+    fun setup() {
+        every { allowedAttributeRepository.save(allowedAttribute) } returns allowedAttribute
+    }
+
+
+    @Test
+    fun `When save an AllowedAttribute should return an AllowedAttribute `() {
+        val allowedAttributeSaved = registerAllowedAttributeUseCase.execute(allowedAttribute)
+
+        assertEquals(allowedAttributeSaved._id, allowedAttribute._id)
+        assertEquals(allowedAttributeSaved.attribute, allowedAttribute.attribute)
+        assertEquals(allowedAttributeSaved.description, allowedAttribute.description)
+        assertEquals(allowedAttributeSaved.values, allowedAttribute.values)
+
+        verify(exactly = 1) { allowedAttributeRepository.save(allowedAttribute) }
+    }
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/RegisterAttributeUseCaseTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/RegisterAttributeUseCaseTest.kt
@@ -1,0 +1,42 @@
+package poc.renanpelicari.tinybrms.business.usecase
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import poc.renanpelicari.tinybrms.CreationUtils
+import poc.renanpelicari.tinybrms.dataprovider.repository.AttributeRepository
+
+@ExtendWith(MockKExtension::class)
+internal class RegisterAttributeUseCaseTest {
+
+    @InjectMockKs
+    lateinit var registerAttributeUseCase: RegisterAttributeUseCase
+
+    @MockK
+    lateinit var attributeRepository: AttributeRepository
+
+    private val attribute = CreationUtils.createAttribute()
+
+    @BeforeAll
+    fun setup() {
+        every { attributeRepository.save(attribute) } returns attribute.copy(_id = "1")
+    }
+
+    @Test
+    fun `When save an Attribute should return an Attribute `() {
+        val attributeSaved = registerAttributeUseCase.execute(attribute)
+
+        assertEquals(attributeSaved._id, "1")
+        assertEquals(attributeSaved.name, attribute.name)
+        assertEquals(attributeSaved.description, attribute.description)
+
+        verify(exactly = 1) { attributeRepository.save(attribute) }
+    }
+
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/RegisterMatcherUseCaseTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/RegisterMatcherUseCaseTest.kt
@@ -1,0 +1,44 @@
+package poc.renanpelicari.tinybrms.business.usecase
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import poc.renanpelicari.tinybrms.CreationUtils
+import poc.renanpelicari.tinybrms.dataprovider.repository.MatcherRepository
+
+@ExtendWith(MockKExtension::class)
+internal class RegisterMatcherUseCaseTest {
+
+    @InjectMockKs
+    lateinit var registerMatchersUseCase: RegisterMatcherUseCase
+
+    @MockK
+    lateinit var matcherRepository: MatcherRepository
+
+    private val matcher = CreationUtils.createMatcher()
+
+    @BeforeEach
+    fun setup() {
+        every { matcherRepository.save(matcher) } returns matcher.copy(_id = "1")
+    }
+
+    @Test
+    fun `When save a Matcher should return a Matcher `() {
+        val matcherSaved = registerMatchersUseCase.execute(matcher)
+
+        assertEquals(matcherSaved._id, "1")
+        assertEquals(matcherSaved.name, matcher.name)
+        assertEquals(matcherSaved.description, matcher.description)
+        assertEquals(matcherSaved.expression, matcher.expression)
+        assertEquals(matcherSaved.values, matcher.values)
+
+        verify(exactly = 1) { matcherRepository.save(matcher) }
+    }
+
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/RegisterRuleUseCaseTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/business/usecase/RegisterRuleUseCaseTest.kt
@@ -1,0 +1,43 @@
+package poc.renanpelicari.tinybrms.business.usecase
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import poc.renanpelicari.tinybrms.CreationUtils
+import poc.renanpelicari.tinybrms.dataprovider.repository.RuleRepository
+
+@ExtendWith(MockKExtension::class)
+internal class RegisterRuleUseCaseTest {
+
+    @InjectMockKs
+    lateinit var registerRuleUseCase: RegisterRuleUseCase
+
+    @MockK
+    lateinit var ruleRepository: RuleRepository
+
+
+    private val rule = CreationUtils.createRule()
+
+    @BeforeEach
+    fun setup() {
+        every { ruleRepository.save(rule) } returns rule.copy(_id = "1")
+    }
+
+    @Test
+    fun `When save a Rule should return a Rule `() {
+        val ruleSaved = registerRuleUseCase.execute(rule)
+
+        assertEquals(ruleSaved._id, "1")
+        assertEquals(ruleSaved.description, rule.description)
+        assertEquals(ruleSaved.matchers, rule.matchers)
+        assertEquals(ruleSaved.allowedValues, rule.allowedValues)
+
+        verify(exactly = 1) { ruleRepository.save(rule) }
+    }
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/dataprovider/enums/ExpressionTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/dataprovider/enums/ExpressionTest.kt
@@ -1,0 +1,291 @@
+package poc.renanpelicari.tinybrms.dataprovider.enums
+
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+internal class ExpressionTest {
+
+    private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+    private val today = LocalDateTime.now()
+    private val yesterday = today.minusDays(1)
+
+
+    @Test
+    fun `Should validate EQUAL_NOT_MATCH_CASE and return true`() {
+        val validate = Expression.EQUAL_NOT_MATCH_CASE.validate(setOf("F"), setOf("F"))
+        assertTrue(validate)
+    }
+
+    @Test
+    fun `Should validate EQUAL_NOT_MATCH_CASE and return false`() {
+        val validate = Expression.EQUAL_NOT_MATCH_CASE.validate(setOf("F"), setOf("M"))
+        assertFalse(validate)
+    }
+
+    @Test
+    fun `Should validade BETWEEN DOUBLE and return true`() {
+        val validate = Expression.BETWEEN_DOUBLE.validate(setOf("10", "50"), setOf("30"))
+        val validate1 = Expression.BETWEEN_DOUBLE.validate(setOf("10", "50"), setOf("10"))
+        val validate2 = Expression.BETWEEN_DOUBLE.validate(setOf("10", "50"), setOf("50"))
+
+        assertTrue(validate)
+        assertTrue(validate1)
+        assertTrue(validate2)
+    }
+
+    @Test
+    fun `Should validade BETWEEN DOUBLE and return false`() {
+        val validate = Expression.BETWEEN_DOUBLE.validate(setOf("10", "50"), setOf("1"))
+        val validate1 = Expression.BETWEEN_DOUBLE.validate(setOf("10", "50"), setOf("9.9"))
+        val validate2 = Expression.BETWEEN_DOUBLE.validate(setOf("10", "50"), setOf("50.1"))
+
+        assertFalse(validate)
+        assertFalse(validate1)
+        assertFalse(validate2)
+    }
+
+    @Test
+    fun `Should validade BETWEEN INTEGER and return true`() {
+        val validate = Expression.BETWEEN_INTEGER.validate(setOf("10", "50"), setOf("30"))
+        val validate1 = Expression.BETWEEN_INTEGER.validate(setOf("10", "50"), setOf("10"))
+        val validate2 = Expression.BETWEEN_INTEGER.validate(setOf("10", "50"), setOf("50"))
+
+        assertTrue(validate)
+        assertTrue(validate1)
+        assertTrue(validate2)
+    }
+
+    @Test
+    fun `Should validade BETWEEN INTEGER and return false`() {
+        val validate = Expression.BETWEEN_INTEGER.validate(setOf("10", "50"), setOf("1"))
+        val validate1 = Expression.BETWEEN_INTEGER.validate(setOf("10", "50"), setOf("9"))
+        val validate2 = Expression.BETWEEN_INTEGER.validate(setOf("10", "50"), setOf("51"))
+
+        assertFalse(validate)
+        assertFalse(validate1)
+        assertFalse(validate2)
+    }
+
+    @Test
+    fun `Should validade CONTAINS and return true`() {
+        val validate = Expression.CONTAINS.validate(setOf("M", "F"), setOf("F"))
+        val validate2 = Expression.CONTAINS.validate(setOf("10", "20"), setOf("10"))
+
+        assertTrue(validate)
+        assertTrue(validate2)
+
+    }
+
+    @Test
+    fun `Should validade CONTAINS and return false`() {
+        val validate = Expression.CONTAINS.validate(setOf("M", "F"), setOf("G"))
+        val validate2 = Expression.CONTAINS.validate(setOf("10", "20"), setOf("15"))
+
+        assertFalse(validate)
+        assertFalse(validate2)
+
+    }
+
+    @Test
+    fun `Should validade NOT_CONTAINS and return true`() {
+        val validate = Expression.NOT_CONTAINS.validate(setOf("M", "F"), setOf("Y"))
+        val validate2 = Expression.NOT_CONTAINS.validate(setOf("10", "20"), setOf("15"))
+
+        assertTrue(validate)
+        assertTrue(validate2)
+
+    }
+
+    @Test
+    fun `Should validade NOT_CONTAINS and return false`() {
+        val validate = Expression.NOT_CONTAINS.validate(setOf("M", "F"), setOf("F"))
+        val validate2 = Expression.NOT_CONTAINS.validate(setOf("10", "20"), setOf("20"))
+
+        assertFalse(validate)
+        assertFalse(validate2)
+
+    }
+
+    @Test
+    fun `Should validade CONTAINS_ALL and return true`() {
+        val validate = Expression.CONTAINS_ALL.validate(setOf("A", "B", "C", "D"), setOf("A", "B"))
+        val validate2 = Expression.CONTAINS_ALL.validate(setOf("10", "20", "30", "40"), setOf("10", "20"))
+
+        assertTrue(validate)
+        assertTrue(validate2)
+
+    }
+
+    @Test
+    fun `Should validade CONTAINS_ALL and return false`() {
+        val validate = Expression.CONTAINS_ALL.validate(setOf("A", "B", "C", "D"), setOf("A", "G"))
+        val validate2 = Expression.CONTAINS_ALL.validate(setOf("10", "20", "30", "40", "50"), setOf("20", "35"))
+
+        assertFalse(validate)
+        assertFalse(validate2)
+
+    }
+
+    @Test
+    fun `Should validade EQUAL and return true`() {
+        val validate = Expression.EQUAL.validate(setOf("A"), setOf("A"))
+        val validate2 = Expression.EQUAL.validate(setOf("10"), setOf("10"))
+
+        assertTrue(validate)
+        assertTrue(validate2)
+    }
+
+    @Test
+    fun `Should validade EQUAL and return false`() {
+        val validate = Expression.EQUAL.validate(setOf("A"), setOf("B"))
+        val validate2 = Expression.EQUAL.validate(setOf("10"), setOf("20"))
+
+        assertFalse(validate)
+        assertFalse(validate2)
+    }
+
+    @Test
+    fun `Should validade HAS_IN and return true`() {
+        val validate = Expression.HAS_IN.validate(setOf("A", "B", "C"), setOf("A"))
+        val validate2 = Expression.HAS_IN.validate(setOf("10", "20", "30"), setOf("10"))
+
+        assertTrue(validate)
+        assertTrue(validate2)
+    }
+
+    @Test
+    fun `Should validade HAS_IN and return false`() {
+        val validate = Expression.HAS_IN.validate(setOf("A", "B", "C"), setOf("G"))
+        val validate2 = Expression.HAS_IN.validate(setOf("10", "20", "30"), setOf("50"))
+
+        assertFalse(validate)
+        assertFalse(validate2)
+    }
+
+    @Test
+    fun `Should validade MORE_THAN and return true`() {
+        val validate = Expression.MORE_THAN.validate(setOf("10"), setOf("30"))
+
+        assertTrue(validate)
+    }
+
+    @Test
+    fun `Should validade MORE_THAN and return false`() {
+        val validate = Expression.MORE_THAN.validate(setOf("80"), setOf("50"))
+
+        assertFalse(validate)
+    }
+
+    @Test
+    fun `Should validade LESS_THAN and return true`() {
+        val validate = Expression.LESS_THAN.validate(setOf("30"), setOf("10"))
+
+        assertTrue(validate)
+    }
+
+    @Test
+    fun `Should validade LESS_THAN and return false`() {
+        val validate = Expression.LESS_THAN.validate(setOf("50"), setOf("80"))
+
+        assertFalse(validate)
+    }
+
+    @Test
+    fun `Should validade EQUAL_OR_MORE_THAN and return true`() {
+        val validate = Expression.EQUAL_OR_MORE_THAN.validate(setOf("10"), setOf("30"))
+        val validateEqual = Expression.EQUAL_OR_MORE_THAN.validate(setOf("10"), setOf("10"))
+
+        assertTrue(validate)
+        assertTrue(validateEqual)
+    }
+
+    @Test
+    fun `Should validade EQUAL_OR_MORE_THAN and return false`() {
+        val validate = Expression.EQUAL_OR_MORE_THAN.validate(setOf("80"), setOf("50"))
+
+        assertFalse(validate)
+    }
+
+    @Test
+    fun `Should validade EQUAL_OR_LESS_THAN and return true`() {
+        val validate = Expression.EQUAL_OR_LESS_THAN.validate(setOf("30"), setOf("10"))
+        val validateEqual = Expression.EQUAL_OR_LESS_THAN.validate(setOf("30"), setOf("30"))
+
+        assertTrue(validate)
+        assertTrue(validateEqual)
+    }
+
+    @Test
+    fun `Should validade EQUAL_OR_LESS_THAN and return false`() {
+        val validate = Expression.EQUAL_OR_LESS_THAN.validate(setOf("50"), setOf("80"))
+
+        assertFalse(validate)
+    }
+
+    @Test
+    fun `Should validade BEFORE_THAN and return true`() {
+        val validate = Expression.BEFORE_THAN.validate(setOf(today.format(formatter)),
+                setOf(yesterday.format(formatter)))
+
+        assertTrue(validate)
+    }
+
+    @Test
+    fun `Should validade BEFORE_THAN and return false`() {
+        val validate = Expression.BEFORE_THAN.validate(setOf(yesterday.format(formatter)),
+                setOf(today.format(formatter)))
+
+        assertFalse(validate)
+    }
+
+    @Test
+    fun `Should validade AFTER_THAN and return true`() {
+        val validate = Expression.AFTER_THAN.validate(setOf(yesterday.format(formatter)),
+                setOf(today.format(formatter)))
+
+        assertTrue(validate)
+    }
+
+    @Test
+    fun `Should validade AFTER_THAN and return false`() {
+        val validate = Expression.AFTER_THAN.validate(setOf(today.format(formatter)),
+                setOf(yesterday.format(formatter)))
+
+        assertFalse(validate)
+    }
+
+    @Test
+    fun `Should validade SAME_DAY and return true`() {
+        val validate = Expression.SAME_DAY.validate(setOf(today.format(formatter)),
+                setOf(today.format(formatter)))
+
+        assertTrue(validate)
+    }
+
+    @Test
+    fun `Should validade SAME_DAY and return false`() {
+        val validate = Expression.SAME_DAY.validate(setOf(today.format(formatter)),
+                setOf(yesterday.format(formatter)))
+
+        assertFalse(validate)
+    }
+
+    @Test
+    fun `Should validade AFTER_DAYS and return true`() {
+        val validate = Expression.AFTER_DAYS.validate(setOf(today.format(formatter)), setOf("2"))
+
+        assertTrue(validate)
+    }
+
+    @Test
+    fun `Should validade AFTER_DAYS and return false`() {
+        val afterTomorrow = today.plusDays(2)
+        val validate = Expression.AFTER_DAYS.validate(setOf(afterTomorrow.format(formatter)), setOf("1"))
+
+        assertFalse(validate)
+    }
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/dataprovider/repository/RuleRepositoryTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/dataprovider/repository/RuleRepositoryTest.kt
@@ -1,0 +1,47 @@
+package poc.renanpelicari.tinybrms.dataprovider.repository
+
+import org.assertj.core.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest
+import org.springframework.data.mongodb.core.MongoTemplate
+import poc.renanpelicari.tinybrms.CreationUtils
+
+@DataMongoTest
+class RuleRepositoryTest @Autowired constructor(
+        val mongoTemplate: MongoTemplate , val ruleRepository: RuleRepository){
+
+
+    private val rule = CreationUtils.createRule()
+    private val ruleMatcherAttributeName = rule.matchers.first().attribute.name
+    private val names = listOf(ruleMatcherAttributeName)
+
+    @BeforeEach
+    fun setup(){
+        mongoTemplate.save(rule)
+    }
+
+    @Test
+    fun `Should return Rules by Matcher Attribute names`(){
+        val rules = ruleRepository.findRulesByMatchersAttributeNameIn(names)
+
+        assertThat(rules.size).isEqualTo(1)
+        assertNotNull(rules.first()._id)
+        assertEquals(rules.first().name, rule.name )
+        assertEquals(rules.first().description, rule.description )
+        assertEquals(rules.first().allowedValues, rule.allowedValues )
+        assertEquals(rules.first().matchers, rule.matchers )
+
+    }
+
+    @Test
+    fun `Should return an empty list of rules`(){
+        var wrongNames = listOf("name1", "name2", "name3")
+        val rules = ruleRepository.findRulesByMatchersAttributeNameIn(wrongNames)
+
+        assertThat(rules.size).isEqualTo(0)
+    }
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/entrypoint/rest/AllowedAttributeControllerTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/entrypoint/rest/AllowedAttributeControllerTest.kt
@@ -1,0 +1,102 @@
+package poc.renanpelicari.tinybrms.entrypoint.rest
+
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import io.mockk.verify
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import poc.renanpelicari.tinybrms.CreationUtils
+import poc.renanpelicari.tinybrms.business.usecase.DeleteAllowedAttributeUseCase
+import poc.renanpelicari.tinybrms.business.usecase.FindAllAllowedAttributesUseCase
+import poc.renanpelicari.tinybrms.business.usecase.RegisterAllowedAttributeUseCase
+
+@ExtendWith(SpringExtension::class)
+@WebMvcTest(AllowedAttributeController::class)
+internal class AllowedAttributeControllerTest(@Autowired val mvc: MockMvc) {
+
+    @MockkBean
+    lateinit var registerAllowedAttributeUseCase: RegisterAllowedAttributeUseCase
+
+    @MockkBean
+    lateinit var findAllAllowedAttributesUseCase: FindAllAllowedAttributesUseCase
+
+    @MockkBean
+    lateinit var deleteAllowedAttributeUseCase: DeleteAllowedAttributeUseCase
+
+    private val allowedAttribute = CreationUtils.createAllowedAttribute()
+    private val list = mutableListOf(allowedAttribute)
+    private var jsonAllowedAttribute = CreationUtils.createAllowedAttributeJson()
+
+    @Test
+    fun `when register an AllowedAttribute should return an AllowedAttribute`() {
+
+        every { registerAllowedAttributeUseCase.execute(allowedAttribute) } returns allowedAttribute
+
+
+        mvc.perform(post("/api/v1/allowed/attribute")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonAllowedAttribute))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.attribute", equalTo(allowedAttribute.attribute)))
+                .andExpect(jsonPath("$.description", equalTo(allowedAttribute.description)))
+                .andExpect(jsonPath("$.values", hasSize<Any>(allowedAttribute.values.size)))
+                .andExpect(jsonPath("$.values[0]", equalTo(allowedAttribute.values.first())))
+                .andExpect(jsonPath("$.values[1]", equalTo(allowedAttribute.values.elementAt(1))))
+                .andExpect(jsonPath("$.values[2]", equalTo(allowedAttribute.values.elementAt(2))))
+
+        verify(exactly = 1) { registerAllowedAttributeUseCase.execute(allowedAttribute) }
+
+    }
+
+    @Test
+    fun `when findAll AllowedAttribute should return a mutable list of AllowedAttribute`() {
+
+        every { findAllAllowedAttributesUseCase.execute() } returns list
+
+        mvc.perform(get("/api/v1/allowed/attribute"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize<Any>(1)))
+                .andExpect(jsonPath("$[0].attribute", equalTo(allowedAttribute.attribute)))
+                .andExpect(jsonPath("$[0].description", equalTo(allowedAttribute.description)))
+                .andExpect(jsonPath("$[0].values", hasSize<Any>(allowedAttribute.values.size)))
+                .andExpect(jsonPath("$[0].values[0]", equalTo(allowedAttribute.values.first())))
+                .andExpect(jsonPath("$[0].values[1]", equalTo(allowedAttribute.values.elementAt(1))))
+                .andExpect(jsonPath("$[0].values[2]", equalTo(allowedAttribute.values.elementAt(2))))
+
+        verify(exactly = 1) { findAllAllowedAttributesUseCase.execute() }
+    }
+
+    @Test
+    fun `when delete an AllowedAttribute by id should return Ok`() {
+
+        every { deleteAllowedAttributeUseCase.execute("1") } answers { nothing }
+
+        mvc.perform(delete("/api/v1/allowed/attribute/1"))
+                .andExpect(status().isOk())
+
+        verify(exactly = 1) { deleteAllowedAttributeUseCase.execute("1") }
+
+    }
+
+    @Test
+    fun `when delete all Attributes should return Ok`() {
+
+        every { deleteAllowedAttributeUseCase.execute() } answers { nothing }
+
+        mvc.perform(delete("/api/v1/allowed/attribute"))
+                .andExpect(status().isOk())
+
+        verify(exactly = 1) { deleteAllowedAttributeUseCase.execute() }
+
+    }
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/entrypoint/rest/AttributeControllerTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/entrypoint/rest/AttributeControllerTest.kt
@@ -1,0 +1,95 @@
+package poc.renanpelicari.tinybrms.entrypoint.rest
+
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import io.mockk.verify
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import poc.renanpelicari.tinybrms.CreationUtils
+import poc.renanpelicari.tinybrms.business.usecase.DeleteAttributeUseCase
+import poc.renanpelicari.tinybrms.business.usecase.FindAllAttributesUseCase
+import poc.renanpelicari.tinybrms.business.usecase.RegisterAttributeUseCase
+
+@ExtendWith(SpringExtension::class)
+@WebMvcTest(AttributeController::class)
+internal class AttributeControllerTest(@Autowired val mvc: MockMvc) {
+
+    @MockkBean
+    lateinit var registerAttributeUseCase: RegisterAttributeUseCase
+
+    @MockkBean
+    lateinit var findAllAttributesUseCase: FindAllAttributesUseCase
+
+    @MockkBean
+    lateinit var deleteAttributeUseCase: DeleteAttributeUseCase
+
+    private val attribute = CreationUtils.createAttribute()
+    private val list = listOf(attribute)
+    private var jsonAttribute = CreationUtils.createAttributeJson()
+
+    @Test
+    fun `when register an Attribute should return an Attribute`() {
+
+        every { registerAttributeUseCase.execute(attribute) } returns attribute.copy(_id = "1")
+
+        mvc.perform(post("/api/v1/attribute")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonAttribute))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._id", equalTo("1")))
+                .andExpect(jsonPath("$.name", equalTo(attribute.name)))
+                .andExpect(jsonPath("$.description", equalTo(attribute.description)))
+
+        verify(exactly = 1) { registerAttributeUseCase.execute(attribute) }
+
+    }
+
+    @Test
+    fun `when findAll Attributes should return a list of Attributes`() {
+
+        every { findAllAttributesUseCase.execute() } returns list
+
+        mvc.perform(get("/api/v1/attribute"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize<Any>(1)))
+                .andExpect(jsonPath("$[0].name", equalTo(attribute.name)))
+                .andExpect(jsonPath("$[0].description", equalTo(attribute.description)))
+
+        verify(exactly = 1) { findAllAttributesUseCase.execute() }
+    }
+
+    @Test
+    fun `when delete an Attribute by id should return Ok`() {
+
+        every { deleteAttributeUseCase.execute("1") } answers { nothing }
+
+        mvc.perform(delete("/api/v1/attribute/1"))
+                .andExpect(status().isOk())
+
+        verify(exactly = 1) { deleteAttributeUseCase.execute("1") }
+
+    }
+
+    @Test
+    fun `when delete all Attributes should return Ok`() {
+
+        every { deleteAttributeUseCase.execute() } answers { nothing }
+
+        mvc.perform(delete("/api/v1/attribute"))
+                .andExpect(status().isOk())
+
+        verify(exactly = 1) { deleteAttributeUseCase.execute() }
+
+    }
+
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/entrypoint/rest/MatcherControllerTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/entrypoint/rest/MatcherControllerTest.kt
@@ -1,0 +1,98 @@
+package poc.renanpelicari.tinybrms.entrypoint.rest
+
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import io.mockk.verify
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import poc.renanpelicari.tinybrms.CreationUtils
+import poc.renanpelicari.tinybrms.business.usecase.DeleteMatcherUseCase
+import poc.renanpelicari.tinybrms.business.usecase.FindAllMatchersUseCase
+import poc.renanpelicari.tinybrms.business.usecase.RegisterMatcherUseCase
+
+@ExtendWith(SpringExtension::class)
+@WebMvcTest(MatcherController::class)
+internal class MatcherControllerTest(@Autowired val mvc: MockMvc) {
+
+    @MockkBean
+    private lateinit var registerMatcherUseCase: RegisterMatcherUseCase
+
+    @MockkBean
+    private lateinit var findAllMatchersUseCase: FindAllMatchersUseCase
+
+    @MockkBean
+    private lateinit var deleteMatcherUseCase: DeleteMatcherUseCase
+
+    private val matcher = CreationUtils.createMatcher()
+    private val list = mutableListOf(matcher)
+    private var jsonMatcher = CreationUtils.createMatcherJson()
+
+    @Test
+    fun `when register a Matcher should return a Matcher`() {
+
+        every { registerMatcherUseCase.execute(matcher) } returns matcher
+
+        mvc.perform(post("/api/v1/matcher")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonMatcher))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name", equalTo(matcher.name)))
+                .andExpect(jsonPath("$.description", equalTo(matcher.description)))
+                .andExpect(jsonPath("$.expression", equalTo(matcher.expression.name)))
+                .andExpect(jsonPath("$.values", hasSize<Any>(matcher.values.size)))
+                .andExpect(jsonPath("$.values[0]", equalTo(matcher.values.first())))
+
+        verify(exactly = 1) { registerMatcherUseCase.execute(matcher) }
+    }
+
+    @Test
+    fun `when findAll Attributes should return a mutable list of Attributes`() {
+
+        every { findAllMatchersUseCase.execute() } returns list
+
+        mvc.perform(get("/api/v1/matcher"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize<Any>(1)))
+                .andExpect(jsonPath("$[0].name", equalTo(matcher.name)))
+                .andExpect(jsonPath("$[0].description", equalTo(matcher.description)))
+                .andExpect(jsonPath("$[0].expression", equalTo(matcher.expression.name)))
+                .andExpect(jsonPath("$[0].values", hasSize<Any>(matcher.values.size)))
+                .andExpect(jsonPath("$[0].values[0]", equalTo(matcher.values.first())))
+
+        verify(exactly = 1) { findAllMatchersUseCase.execute() }
+    }
+
+    @Test
+    fun `when delete an Attribute by id should return Ok`() {
+
+        every { deleteMatcherUseCase.execute("1") } answers { nothing }
+
+        mvc.perform(delete("/api/v1/matcher/1"))
+                .andExpect(status().isOk())
+
+        verify(exactly = 1) { deleteMatcherUseCase.execute("1") }
+
+    }
+
+    @Test
+    fun `when delete all Attributes should return Ok`() {
+
+        every { deleteMatcherUseCase.execute() } answers { nothing }
+
+        mvc.perform(delete("/api/v1/matcher"))
+                .andExpect(status().isOk())
+
+        verify(exactly = 1) { deleteMatcherUseCase.execute() }
+
+    }
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/entrypoint/rest/RuleControllerTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/entrypoint/rest/RuleControllerTest.kt
@@ -1,0 +1,129 @@
+package poc.renanpelicari.tinybrms.entrypoint.rest
+
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import io.mockk.verify
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import poc.renanpelicari.tinybrms.CreationUtils
+import poc.renanpelicari.tinybrms.business.usecase.DeleteRuleUseCase
+import poc.renanpelicari.tinybrms.business.usecase.FindAllRulesUseCase
+import poc.renanpelicari.tinybrms.business.usecase.RegisterRuleUseCase
+
+@ExtendWith(SpringExtension::class)
+@WebMvcTest(RuleController::class)
+internal class RuleControllerTest(@Autowired val mvc: MockMvc) {
+
+    @MockkBean
+    private lateinit var registerRuleUseCase: RegisterRuleUseCase
+
+    @MockkBean
+    private lateinit var findAllRulesUseCase: FindAllRulesUseCase
+
+    @MockkBean
+    private lateinit var deleteRuleUseCase: DeleteRuleUseCase
+
+    private val rule = CreationUtils.createRule()
+    private val list = mutableListOf(rule)
+    private var jsonRule = CreationUtils.createRuleJson()
+
+    @Test
+    fun `when register a Rule should return a Rule`() {
+
+        every { registerRuleUseCase.execute(rule) } returns rule
+
+        mvc.perform(post("/api/v1/rule")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonRule))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name", equalTo(rule.name)))
+                .andExpect(jsonPath("$.description", equalTo(rule.description)))
+
+                .andExpect(jsonPath("$.matchers", hasSize<Any>(rule.matchers.size)))
+                .andExpect(jsonPath("$.matchers[0].name", equalTo(rule.matchers.first().name)))
+                .andExpect(jsonPath("$.matchers[0].description", equalTo(rule.matchers.first().description)))
+                .andExpect(jsonPath("$.matchers[0].expression", equalTo(rule.matchers.first().expression.name)))
+
+                .andExpect(jsonPath("$.matchers[0].values", hasSize<Any>(rule.matchers.first().values.size)))
+                .andExpect(jsonPath("$.matchers[0].values[0]", equalTo(rule.matchers.first().values.first())))
+
+                .andExpect(jsonPath("$.allowedValues", hasSize<Any>(rule.allowedValues.size)))
+                .andExpect(jsonPath("$.allowedValues[0].attribute", equalTo(rule.allowedValues.first().attribute)))
+                .andExpect(jsonPath("$.allowedValues[0].description", equalTo(rule.allowedValues.first().description)))
+
+                .andExpect(jsonPath("$.allowedValues[0].values", hasSize<Any>(rule.allowedValues.first().values.size)))
+                .andExpect(jsonPath("$.allowedValues[0].values[0]", equalTo(rule.allowedValues.first().values.first())))
+                .andExpect(jsonPath("$.allowedValues[0].values[1]", equalTo(rule.allowedValues.first().values.elementAt(1))))
+                .andExpect(jsonPath("$.allowedValues[0].values[2]", equalTo(rule.allowedValues.first().values.elementAt(2))))
+
+
+        verify(exactly = 1) { registerRuleUseCase.execute(rule) }
+    }
+
+    @Test
+    fun `when findAll Rule should return a mutable list of Rule`() {
+
+        every { findAllRulesUseCase.execute() } returns list
+
+        mvc.perform(get("/api/v1/rule"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize<Any>(1)))
+                .andExpect(jsonPath("$[0].name", equalTo(rule.name)))
+                .andExpect(jsonPath("$[0].description", equalTo(rule.description)))
+
+                .andExpect(jsonPath("$[0].matchers", hasSize<Any>(rule.matchers.size)))
+                .andExpect(jsonPath("$[0].matchers[0]._id", equalTo(rule.matchers.first()._id)))
+                .andExpect(jsonPath("$[0].matchers[0].name", equalTo(rule.matchers.first().name)))
+                .andExpect(jsonPath("$[0].matchers[0].description", equalTo(rule.matchers.first().description)))
+                .andExpect(jsonPath("$[0].matchers[0].expression", equalTo(rule.matchers.first().expression.name)))
+
+                .andExpect(jsonPath("$[0].matchers[0].values", hasSize<Any>(rule.matchers.first().values.size)))
+                .andExpect(jsonPath("$[0].matchers[0].values[0]", equalTo(rule.matchers.first().values.first())))
+
+                .andExpect(jsonPath("$[0].allowedValues", hasSize<Any>(rule.allowedValues.size)))
+                .andExpect(jsonPath("$[0].allowedValues[0]._id", equalTo(rule.allowedValues.first()._id)))
+                .andExpect(jsonPath("$[0].allowedValues[0].attribute", equalTo(rule.allowedValues.first().attribute)))
+                .andExpect(jsonPath("$[0].allowedValues[0].description", equalTo(rule.allowedValues.first().description)))
+
+                .andExpect(jsonPath("$[0].allowedValues[0].values", hasSize<Any>(rule.allowedValues.first().values.size)))
+                .andExpect(jsonPath("$[0].allowedValues[0].values[0]", equalTo(rule.allowedValues.first().values.first())))
+                .andExpect(jsonPath("$[0].allowedValues[0].values[1]", equalTo(rule.allowedValues.first().values.elementAt(1))))
+                .andExpect(jsonPath("$[0].allowedValues[0].values[2]", equalTo(rule.allowedValues.first().values.elementAt(2))))
+
+        verify(exactly = 1) { findAllRulesUseCase.execute() }
+    }
+
+    @Test
+    fun `when delete an AllowedAttribute by id should return Ok`() {
+
+        every { deleteRuleUseCase.execute("1") } answers { nothing }
+
+        mvc.perform(delete("/api/v1/rule/1"))
+                .andExpect(status().isOk())
+
+        verify(exactly = 1) { deleteRuleUseCase.execute("1") }
+
+    }
+
+    @Test
+    fun `when delete all Attributes should return Ok`() {
+
+        every { deleteRuleUseCase.execute() } answers { nothing }
+
+        mvc.perform(delete("/api/v1/rule"))
+                .andExpect(status().isOk())
+
+        verify(exactly = 1) { deleteRuleUseCase.execute() }
+
+    }
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/entrypoint/vo/AllowedAttributeVoTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/entrypoint/vo/AllowedAttributeVoTest.kt
@@ -1,0 +1,19 @@
+package poc.renanpelicari.tinybrms.entrypoint.vo
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import poc.renanpelicari.tinybrms.CreationUtils
+
+internal class AllowedAttributeVoTest {
+
+    private val allowedAttributeVo = CreationUtils.createAllowedAttributeVo()
+
+    @Test
+    fun `Should return an AllowedAttribute domain`() {
+        val allowedAttribute = allowedAttributeVo.toDomain()
+
+        assertThat(allowedAttributeVo).isEqualToIgnoringGivenFields(allowedAttribute, allowedAttribute._id)
+
+    }
+
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/entrypoint/vo/AttributeVoTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/entrypoint/vo/AttributeVoTest.kt
@@ -1,0 +1,17 @@
+package poc.renanpelicari.tinybrms.entrypoint.vo
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import poc.renanpelicari.tinybrms.CreationUtils
+
+internal class AttributeVoTest {
+
+    private val attributeVo = CreationUtils.createAttributeVo()
+
+    @Test
+    fun `Should return an Attribute domain`() {
+        val attribute = attributeVo.toDomain()
+
+        assertThat(attributeVo).isEqualToIgnoringGivenFields(attribute, attribute._id)
+    }
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/entrypoint/vo/MatcherVoTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/entrypoint/vo/MatcherVoTest.kt
@@ -1,0 +1,18 @@
+package poc.renanpelicari.tinybrms.entrypoint.vo
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import poc.renanpelicari.tinybrms.CreationUtils
+
+internal class MatcherVoTest {
+
+
+    private val matcherVo = CreationUtils.createMatcherVo()
+
+    @Test
+    fun `Should return a Matcher domain`() {
+        val matcher = matcherVo.toDomain()
+
+        assertThat(matcherVo).isEqualToIgnoringGivenFields(matcher, matcher._id)
+    }
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/entrypoint/vo/RuleValidationVoTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/entrypoint/vo/RuleValidationVoTest.kt
@@ -1,0 +1,29 @@
+package poc.renanpelicari.tinybrms.entrypoint.vo
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class RuleValidationVoTest {
+
+    private val ruleValidation = RuleValidationVo(attribute = "sexo", values = setOf("M"))
+    private val ruleValidation2 = RuleValidationVo(attribute = "peso", values = setOf("55.0"))
+    private val listRuleValidation = listOf(ruleValidation, ruleValidation2)
+
+    @Test
+    fun `Should return a Pair of a RuleValidationVo list`() {
+        val pair = listRuleValidation.toPairList()
+
+        assertEquals(pair.size, listRuleValidation.size)
+        assertEquals(pair.first().first, listRuleValidation.first().attribute)
+        assertEquals(pair.first().second, listRuleValidation.first().values)
+    }
+
+    @Test
+    fun `Should return a Pair of a RuleValidationVo`() {
+        val pair = ruleValidation.toPair()
+
+        assertEquals(pair.first, ruleValidation.attribute)
+        assertEquals(pair.second, ruleValidation.values)
+    }
+
+}

--- a/src/test/kotlin/poc/renanpelicari/tinybrms/entrypoint/vo/RuleVoTest.kt
+++ b/src/test/kotlin/poc/renanpelicari/tinybrms/entrypoint/vo/RuleVoTest.kt
@@ -1,0 +1,17 @@
+package poc.renanpelicari.tinybrms.entrypoint.vo
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import poc.renanpelicari.tinybrms.CreationUtils
+
+internal class RuleVoTest {
+
+    private val ruleVo = CreationUtils.createRuleVo()
+
+    @Test
+    fun `Should return a Rule domain`() {
+        val rule = ruleVo.toDomain()
+
+        assertThat(ruleVo).isEqualToIgnoringGivenFields(rule, rule._id)
+    }
+}


### PR DESCRIPTION
Adicionado as dependencias do **jUnit 5** e do **Mockk**.
Criado as classes de testes de exemplos das camadas UseCase, Controller e Repository, além do Enum e VOs.
Foi adicionado o arquivo de configuração junit-platform.properties para modificar o comportamento padrão dos testes fazendo com seja executado os testes uma vez por classe, tornando estáticos de uma forma mais amigável e menos trabalhosa. 
Foi criada a classe CreationUtils para facilitar nos testes, sendo utilizado para criar as instancias de data class conforme https://phauer.com/2018/best-practices-unit-testing-kotlin/#use-helper-functions-with-default-arguments-to-ease-object-creation

Referência de MockK with Springboot e kotlin: https://spring.io/guides/tutorials/spring-boot-kotlin/
